### PR TITLE
add .nojekyll for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
       cd docs
       make html
       cd ../
-      doctr deploy . --built-docs docs/_build/html
+      doctr deploy . --built-docs docs/_build/html --command "touch .nojekyll; git add .nojekyll"
     fi
 
 after_success:


### PR DESCRIPTION
This should add the .nojekyll file if it does not exists to the base repository. Without it, github will not render the docs pages properly. The changes to the .yml should add and commit the file.