### PR TITLE
adding link to docs

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -11,3 +11,4 @@ Authors: Nolan Brown, Victor Nieto, Ryan Dudschus, Daniel Douty
 
 Epics remote alert system
 
+See the `docs <https://slaclab.github.io/ease/>`_ for info.


### PR DESCRIPTION
Add a link in the readme to the sphinx-generated doctr-made github-hosted free-range grass-fed documentation. 