### PR TITLE
Add logger

### DIFF
--- a/web_interface/web_interface/settings.py
+++ b/web_interface/web_interface/settings.py
@@ -61,6 +61,68 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+
+
+
+
+if DEBUG:
+    handler = 'console'
+    django_level = 'INFO'
+    app_level = 'DEBUG'
+    formatter = 'neat'
+else:
+    handler = 'file'
+    django_level = 'WARNING'
+    app_level = 'WARNING'
+    formatter = 'verbose'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+
+    'formatters': {
+        'neat': {
+            'format':'[%(asctime)s] %(message)s',
+            #srftime format
+            'datefmt':'%a %b/%d/%y %I:%M:%S %p',
+        },
+        'verbose':{
+            'format':'[%(asctime)s][%(levelname)s][%(name)s] %(message)s'
+        },
+    },
+
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': formatter,
+        },
+        'file': {
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': 'ease_log.log',
+            'when': 'midnight',
+            #'interval': 24,
+            'backupCount':100,
+            'formatter': formatter,
+        },
+    },
+    
+    'loggers': {
+        'django': {
+            'handlers': [handler],
+            'level': django_level,
+        },
+        'alert_config_app': {
+            'handlers': [handler],
+            'level': app_level,
+        },
+        'account_mgr_app': {
+            'handlers': [handler],
+            'level': app_level,
+        },
+    },
+}
+
+
 ALLOWED_HOSTS = [
     "134.79.165.105",
     "pswww-dev.slac.stanford.edu",

--- a/web_interface/web_interface/settings.py
+++ b/web_interface/web_interface/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import os
 import sys
+from datetime import datetime
 
 # https://stackoverflow.com/questions/4664724/distributing-django-projects-with-unique-secret-keys/16630719#16630719
 # Import/regenerate secret key upon downloading source. Live key should never go to repo
@@ -61,20 +62,19 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-
-
-
-
-if DEBUG:
+if 0:
     handler = 'console'
     django_level = 'INFO'
     app_level = 'DEBUG'
     formatter = 'neat'
 else:
     handler = 'file'
-    django_level = 'WARNING'
+    django_level = 'INFO'
     app_level = 'WARNING'
     formatter = 'verbose'
+    time_stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    logs_folder = "session_logs_" + time_stamp
+    os.mkdir(logs_folder)
 
 LOGGING = {
     'version': 1,
@@ -98,10 +98,10 @@ LOGGING = {
         },
         'file': {
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': 'ease_log.log',
+            'filename': os.path.join(logs_folder,'log.log'),
             'when': 'midnight',
             #'interval': 24,
-            'backupCount':100,
+            'backupCount':500,
             'formatter': formatter,
         },
     },
@@ -121,7 +121,6 @@ LOGGING = {
         },
     },
 }
-
 
 ALLOWED_HOSTS = [
     "134.79.165.105",


### PR DESCRIPTION
PR contains:
 - Common logger for all files 
 - Differentiation between Debug/non-Debug logging
   - Debug prints a shorter message to the console for DEBUG and higher tier messages 
   - non-Debug prints a more detailed message to a file for WARN and higher tier messages 
     - New logger files are generated and separated by 24 hour periods, swapping at midnight
     - Logger files are separated into new folders for each time ease is launched 
 - Remember to add `logger = logging.getLogger(__name__)` at the start of files using logging 
