### PR TITLE
Fix nonuser redirects

### DIFF
--- a/web_interface/account_mgr_app/tests/test_login.py
+++ b/web_interface/account_mgr_app/tests/test_login.py
@@ -25,7 +25,7 @@ class LoginTests(TestCase):
         #self.c.login(username="test",password="testpass")
         with self.assertTemplateUsed(
                     template_name='registration/login.html'):
-            response = self.c.get('/acct/login/')
+            response = self.c.get('/accounts/login/')
             #alternative syntax
             #self.assertTemplateNotUsed(response, 'registration/login.html')
         self.c.logout()

--- a/web_interface/account_mgr_app/views.py
+++ b/web_interface/account_mgr_app/views.py
@@ -21,10 +21,6 @@ from django.core.mail import EmailMessage
 from email.mime.text import MIMEText
 import smtplib 
 
-# Create your views here.
-
-
-
 
 def signup(request):
     if request.method == 'POST':
@@ -58,8 +54,6 @@ def signup(request):
         # form = UserCreationForm()
         form = SignUpForm()
     return render(request, 'signup.html', {'form': form})
-    
-    
     
     
 def activate(request, uidb64, token):

--- a/web_interface/alert_config_app/views.py
+++ b/web_interface/alert_config_app/views.py
@@ -13,7 +13,7 @@ from django.views.generic.edit import (CreateView, UpdateView, DeleteView)
 
 from account_mgr_app.models import Profile
 import account_mgr_app
-from .models import Alert, Pv, Trigger #PVname #Does this allow you to say "model = Pv....model = Alert..."
+from .models import Alert, Pv, Trigger 
 from .forms import configAlert, configTrigger, deleteAlert, detailAlert, createPv
 
 from django.contrib.auth.decorators import login_required
@@ -35,45 +35,30 @@ from django.db import transaction, IntegrityError, models
 from django.contrib import messages
 
 
-
-# login_url = reverse('login')
-# login_url = '/acct/login/'
-
-
-
-# Create your views here.
 @login_required()
 def list_all(request):
     """Currently unused - Draw a page with a full list of PVs and Alerts.
 
     Attributes
-    __________
-        request : django.http.HttpRequest
+    ----------
+    request : django.http.HttpRequest
 
+    
     Returns
     -------
-        render : django.http.HttpResponse
+    django.http.HttpResponse
     """
     context = {}
     context['pv_list'] = Pv.objects.all()
     context['alert_list'] = Alert.objects.all()
     context['user'] = request.user
     return render( request, 'debug_list_all.html', context)
-    #return HttpResponse("<h1>Page is alive</h1>")
 
 
-#@login_required()
-#def title(request):
-#    context = {}
-#    context['user'] = request.user
-#    return render( request, 'title.html', context)
-#------------------------------------------------------------------------------
 @method_decorator(login_required, name = 'dispatch')
 class Title_page(generic.ListView):
-    #model = Alert
     template_name = 'title.html'
     form_class = configAlert
-#    context_object_name='alert'
     paginate_by = 30
     
     def title(request):
@@ -84,30 +69,8 @@ class Title_page(generic.ListView):
     def get_queryset(self):
         new_context = Alert.objects.all().order_by('name')
         return new_context
-        #return render(request, self.template_name, {'new_context': new_context })
-    
-    
-#    def form_valid(self,form):
-#        # form.cleaned_data.get('new_name')
-#        form.instance.name = form.data['new_subscribe']
-#
-#        return super().form_valid(form)
-#------------------------------------------------------------------------------
+   
 
-
-
-# def pvs(request):
-#     context = {}
-#     context['pv_list'] = Pv.objects.all()
-#     context['user'] = request.user
-#     return render( request, 'pvs.html', context)
-
-# def alerts(request):
-#     context = {}
-#     context['alert_list'] = Alert.objects.all()
-#     context['user'] = request.user
-#     return render( request, 'alerts.html', context)
-    
 @method_decorator(login_required, name = 'dispatch')
 class alerts_all(generic.ListView):
     """Currently unused - Draw a page with a full list of PVs and Alerts
@@ -130,6 +93,7 @@ class alerts_all(generic.ListView):
         if query:
             new_context = new_context.filter(name__icontains=query)#
         return new_context
+
 
 @method_decorator(login_required, name = 'dispatch')
 class pvs_all(generic.ListView):
@@ -156,6 +120,7 @@ class pvs_all(generic.ListView):
             new_context = new_context.filter(name__icontains=query) 
         return new_context
 
+
 @method_decorator(login_required, name = 'dispatch')
 class pv_detail(generic.DetailView, UpdateView):
     model = Pv
@@ -175,7 +140,6 @@ class pv_delete(DeleteView):
     model = Pv
     template_name = 'pv_delete.html'
     success_url = reverse_lazy('pvs_page_all')
-
 
 
 @method_decorator(login_required, name = 'dispatch')
@@ -201,14 +165,6 @@ class pv_create(generic.edit.CreateView):
         form.instance.name = form.cleaned_data.get('new_name')
         form.save()
         return super(pv_create, self).form_valid(form)
-
-
-# @method_decorator(login_required, name = 'dispatch')
-# class alert_detail(generic.DetailView):
-#     model = Alert
-#     context_object_name='alert'
-#     template_name = 'alert_detail.html'
-
 
 
 @method_decorator(login_required, name = 'dispatch')
@@ -520,37 +476,3 @@ def alert_delete(request,pk=None,*args,**kwargs):
         {'form':deleteForm,'alert':alert_inst},
     )
 
-
-#def profile(request):
-#    args = {'user': request.user}
-#    return render(request, 'profile.html', args)
-#    
-#def edit_profile(request):
-#    if request.method == 'POST':
-#        form = EditProfileForm(request.POST, instance=request.user)
-#        
-#        if form.is_valid():
-#            form.save()
-#            return redirect('/alert/profile')
-#            
-#    else:
-#        form = EditProfileForm(instance=request.user)
-#        args = {'form': form}
-#        return render(request, 'edit_profile.html', args)
-#    
-#    
-#def change_password(request):
-#    if request.method == 'POST':
-#        form = PasswordChangeForm(data=request.POST, user=request.user)
-#        
-#        if form.is_valid():
-#            form.save()
-#            update_session_auth_hash(request, form.user)
-#            return redirect('/alert/profile')
-#        else:
-#            return redirect('/alert/profile/change_password')
-#    else:
-#        form = PasswordChangeForm(user=request.user)
-#        args = {'form': form}
-#        return render(request, 'change_password.html', args)
-#        

--- a/web_interface/web_interface/settings.py
+++ b/web_interface/web_interface/settings.py
@@ -56,9 +56,16 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEBUG = True
 
 time_stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-logs_folder = "session_logs_" + time_stamp
-if not os.path.exists(logs_folder):
-    os.mkdir(logs_folder)
+logs_folder_base = "session_logs_" + time_stamp
+logs_folder = logs_folder_base 
+idx = 0 
+while os.path.exists(logs_folder):
+    logs_folder = logs_folder_base + "_" + str(idx)
+    idx += 1
+
+os.mkdir(logs_folder)
+
+logfile_name = os.path.join(logs_folder, str(os.getpid())+'.log')
 
 if DEBUG:
     handler = 'console'
@@ -94,7 +101,7 @@ LOGGING = {
         },
         'file': {
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(logs_folder, str(os.getpid())+'.log'),
+            'filename': logfile_name,
             'when': 'midnight',
             #'interval': 24,
             'backupCount':500,

--- a/web_interface/web_interface/settings.py
+++ b/web_interface/web_interface/settings.py
@@ -250,9 +250,13 @@ EMAIL_HOST = 'psmail'
 EMAIL_PORT = 25
 EMAIL_HOST_USER = 'EASE'
 DEFAULT_FROM_EMAIL = 'EASE'
+
+
 if not DEBUG:
     LOGIN_REDIRECT_URL = FORCE_SCRIPT_NAME + '/alert/title'
+    LOGIN_URL = FORCE_SCRIPT_NAME + '/accounts/login'
 else:
     LOGIN_REDIRECT_URL = '/alert/title'
+    LOGIN_URL = '/accounts/login'
 
 ACCOUNT_ACTIVATION_DAYS = 7

--- a/web_interface/web_interface/settings.py
+++ b/web_interface/web_interface/settings.py
@@ -58,7 +58,8 @@ DEBUG = True
 time_stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
 logs_folder_base = "session_logs_" + time_stamp
 logs_folder = logs_folder_base 
-idx = 0 
+idx = 0
+
 while os.path.exists(logs_folder):
     logs_folder = logs_folder_base + "_" + str(idx)
     idx += 1

--- a/web_interface/web_interface/urls.py
+++ b/web_interface/web_interface/urls.py
@@ -14,16 +14,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf.urls import url, include
-from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/accounts/login')),#This take you right to /acct/login
-    #url(r'^admin/', admin.site.urls),
     url(r'^alert/', include('alert_config_app.urls')),
     url(r'^accounts/', include('account_mgr_app.urls')),
-
-    # url(r'^login/$', auth_views.login, name='login'),
-    # url(r'^logout/$', auth_views.logout, name='logout'),
 ]

--- a/web_interface/web_interface/urls.py
+++ b/web_interface/web_interface/urls.py
@@ -19,10 +19,10 @@ from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
 
 urlpatterns = [
-    url(r'^$', RedirectView.as_view(url='/acct/login')),#This take you right to /acct/login
+    url(r'^$', RedirectView.as_view(url='/accounts/login')),#This take you right to /acct/login
     #url(r'^admin/', admin.site.urls),
     url(r'^alert/', include('alert_config_app.urls')),
-    url(r'^acct/', include('account_mgr_app.urls')),
+    url(r'^accounts/', include('account_mgr_app.urls')),
 
     # url(r'^login/$', auth_views.login, name='login'),
     # url(r'^logout/$', auth_views.logout, name='logout'),


### PR DESCRIPTION
Previously, redirects to the login pages sent users to the /accounts/login page when all login pages were behind /acct/login. The settings have been updated so the /accounts/login is no longer simply assumed from django defaults and all account management pages have been moved to /accounts/login