### PR TITLE
Search helper incorporates real names when searching for owners.

### DIFF
--- a/web_interface/alert_config_app/forms.py
+++ b/web_interface/alert_config_app/forms.py
@@ -259,9 +259,6 @@ class configAlert(forms.Form):#ModelForm
         
         # produce list of individual usernames from textbox
         name_set = self.parse_usernames(data)
-        #name_list = [name.strip() for name in data.split(",")]
-        #name_set = set(name_list)
-        #name_set = name_set - set(['',' '])
 
         # search database 
         profile_list = Profile.objects.filter(user__username__in=name_set)

--- a/web_interface/alert_config_app/forms.py
+++ b/web_interface/alert_config_app/forms.py
@@ -19,6 +19,7 @@ from django.contrib.auth.forms import UserChangeForm
 from django.contrib.auth.models import User
 
 from .widgets import HorizontalCheckbox
+import re
 
 
 class configTrigger(forms.Form):
@@ -199,9 +200,50 @@ class configAlert(forms.Form):#ModelForm
                 'rows':'5',
             }
         ),
-        help_text = "Users who can edit this alert"
+        help_text = "Users who can edit this alert. "
+            +"Separate with commas or semicolons"
     )
-    
+
+    @staticmethod
+    def parse_usernames(data):
+        """ Receive string of usernames separated by commas, first/last
+        optional and extract the username strings.
+
+        
+        Parameters
+        ----------
+        data : str
+            This takes a string containing the usernames. Usernames must be
+            comma separated and may optionally be followed by  '(last_name,
+            first_name'. The first and last names are not checked, they are
+            only present for user readability and will be removed
+
+        Returns
+        -------
+        :obj:`set` of :obj:`str`
+            List of username strings.
+            
+        """
+        pattern = "[^\(\),]+\([^\(\)]+\)|[^\(\),]+" 
+        # extract comma separated groups of 'username' and 'username (str,str)'
+        parsed_groups = re.findall(pattern, data)
+
+        parsed_names = []
+        for group in parsed_groups:
+            match = re.search(
+                "[^\(\),]+",
+                group
+            )
+            if match:
+                parsed_names.append(match.group())   
+
+        # remove trailing/leading whitespace
+        parsed_names = set([name.strip() for name in parsed_names])
+        parsed_names = parsed_names - set([''])
+
+        return parsed_names
+
+
     def clean_new_owners(self):
         """Receive input string for the new_owners field and return users list
 
@@ -216,9 +258,10 @@ class configAlert(forms.Form):#ModelForm
         data = self.cleaned_data['new_owners']
         
         # produce list of individual usernames from textbox
-        name_list = [name.strip() for name in data.split(",")]
-        name_set = set(name_list)
-        name_set = name_set - set(['',' '])
+        name_set = self.parse_usernames(data)
+        #name_list = [name.strip() for name in data.split(",")]
+        #name_set = set(name_list)
+        #name_set = name_set - set(['',' '])
 
         # search database 
         profile_list = Profile.objects.filter(user__username__in=name_set)

--- a/web_interface/alert_config_app/tests/test_forms.py
+++ b/web_interface/alert_config_app/tests/test_forms.py
@@ -193,6 +193,61 @@ class test_config_Alert_form(TestCase):
             "Profile not returned"
         )
 
+    def test_parse_usernames(self):
+        """Ensure that the parse_usernames method properly extracts usernames
+        from possible input strings
+        """
+        data = "username"
+        result = configAlert.parse_usernames(data)
+        self.assertEqual(
+            result,
+            set(["username"]),
+            "unable to handle single username-only entries"
+        )
+
+        data = "username1,username2,username3"
+        result = configAlert.parse_usernames(data)
+        self.assertEqual(
+            result,
+            set(["username1","username2","username3"]),
+            "unable to handle multiple, username-only entries"
+        )
+        
+        data = "username (first, last)"
+        result = configAlert.parse_usernames(data)
+        self.assertEqual(
+            result,
+            set(["username"]),
+            "unable to handle single username w/ name"
+        )
+
+        data = "user1(first,last),user2 (  first,last),user3 (first, last)"
+        result = configAlert.parse_usernames(data)
+        self.assertEqual(
+            result,
+            set(["user1","user2","user3"]),
+            "unable to handle multiple, username-only entries"
+        )
+
+        data = "user1(first, last   ),user2  ,user3 ( first, last)"
+        result = configAlert.parse_usernames(data)
+        self.assertEqual(
+            result,
+            set(["user1","user2","user3"]),
+            "unable to handle multiple, mixed-type entries"
+        )
+        
+        data = "user1(first, last   ),user2 , ,user3 ( first, last)"
+        result = configAlert.parse_usernames(data)
+        self.assertEqual(
+            result,
+            set(["user1","user2","user3"]),
+            "unable to scrub blank (bad) entires"
+        )
+
+
+
+
 class test_detail_Alert_form(TestCase):
     """Collection of tests inspecting the detail_alert form 
     """

--- a/web_interface/alert_config_app/views.py
+++ b/web_interface/alert_config_app/views.py
@@ -313,7 +313,6 @@ class alert_config(View):
                 profile__in=alert_inst.owner.all()
             )
 
-            #initial_usernames = [usr.username for usr in initial_owner_list]
             
             initial_usernames =  [
                 u.username + " (" + u.last_name + ", " + u.first_name + ")" 

--- a/web_interface/alert_config_app/views.py
+++ b/web_interface/alert_config_app/views.py
@@ -342,8 +342,11 @@ class alert_config(View):
             initial = trigger_initial,
             prefix='tg'
         )
-        
-        all_usernames = sorted([usr.username for usr in User.objects.all()])
+        all_usernames =  [
+            u.username + " (" + u.last_name + ", " + u.first_name + ")" 
+            for u in User.objects.all()
+        ]
+        all_usernames = sorted(all_usernames)
 
         return render(
             request = request, 

--- a/web_interface/alert_config_app/views.py
+++ b/web_interface/alert_config_app/views.py
@@ -313,7 +313,12 @@ class alert_config(View):
                 profile__in=alert_inst.owner.all()
             )
 
-            initial_usernames = [usr.username for usr in initial_owner_list]
+            #initial_usernames = [usr.username for usr in initial_owner_list]
+            
+            initial_usernames =  [
+                u.username + " (" + u.last_name + ", " + u.first_name + ")" 
+                for u in initial_owner_list
+            ]
 
             initial_owners = ", ".join(sorted(initial_usernames))
 


### PR DESCRIPTION
The owners field in the alert config page now works with real names in addition to usernames. 
New features: 
 - Users can search for other users using both usernames and real names
 - The owners field displays real names
